### PR TITLE
remove unrequired rusty-actions from workflows

### DIFF
--- a/.github/workflows/dns.yml
+++ b/.github/workflows/dns.yml
@@ -38,13 +38,6 @@ jobs:
           role-to-assume: ${{ secrets.DNS_GHA_ROLE }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./cloudformation/dns/template.yaml
-          profile: ${{ secrets.DOCS_SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
         working-directory: ./cloudformation/dns
         run: sam validate --region ${{ env.AWS_REGION }}

--- a/.github/workflows/docs-waf.yml
+++ b/.github/workflows/docs-waf.yml
@@ -38,13 +38,6 @@ jobs:
           role-to-assume: ${{ secrets.DOCS_WAF_GHA_ROLE }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./cloudformation/docs-waf/template.yaml
-          profile: ${{ secrets.DOCS_SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
         working-directory: ./cloudformation/docs-waf
         run: sam validate --region ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the rusty actions from the config management workflows

### Why did it change

This is no longer required as using the dev-platform upload action which handles this instead.

### Issue tracking

- [IPS-503](https://govukverify.atlassian.net/browse/IPS-503)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

[IPS-503]: https://govukverify.atlassian.net/browse/IPS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ