### PR TITLE
Fix tech docs repo name for trust policy

### DIFF
--- a/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
+++ b/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
@@ -145,7 +145,7 @@ module "tech-docs-pipeline" {
     ContainerSignerKmsKeyArn   = data.aws_cloudformation_stack.container-signer.outputs["ContainerSignerKmsKeyArn"]
     SigningProfileArn          = data.aws_cloudformation_stack.aws-signer.outputs["SigningProfileArn"]
     SigningProfileVersionArn   = data.aws_cloudformation_stack.aws-signer.outputs["SigningProfileVersionArn"]
-    OneLoginRepositoryName     = "authentication-tech-docs"
+    OneLoginRepositoryName     = "tech-docs"
     SlackNotificationType      = "Failures"
     BuildNotificationStackName = "di-documentation-notifications"
   }


### PR DESCRIPTION
The trust policy was drifted to the correct name, then set back to the old one - this is setting to the correct one in IAC