### PR TITLE
BAU: Update codeowners to the new Identity SRE GitHub team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/digital-identity-sres
+* @govuk-one-login/identity-sre


### PR DESCRIPTION
The old `digital-identity-sres` team has only one member. Update the codeowners to the new Identity SRE team called `identity-sre`.