### PR TITLE
[IPS-2341] Change CODEOWNERS from ID-SRE to REX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/identity-sre
+* @govuk-one-login/reliability-engineering-x


### PR DESCRIPTION
Identity SRE have become a cross cutting SRE team under a new name, this changes the ownership from the old team to the new team

https://govukverify.atlassian.net/browse/IPS-2341