### PR TITLE
REX-176: Enabling SpokeVPC parameter in tech-docs-pipeline

### DIFF
--- a/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
+++ b/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
@@ -209,7 +209,7 @@ module "team-manual-pipeline" {
 }
 
 module "tech-docs-pipeline" {
-  source     = "git@github.com:govuk-one-login/ipv-terraform-modules.git//secure-pipeline/deploy-pipeline"
+  source     = "git@github.com:govuk-one-login/ipv-terraform-modules.git//secure-pipeline/deploy-pipeline?ref=deploy-pipeline-cfv2.108.0-tfv0.3.0"
   stack_name = "tech-docs-pipeline"
   parameters = {
     SAMStackName               = "tech-docs"
@@ -224,7 +224,7 @@ module "tech-docs-pipeline" {
     OneLoginRepositoryName     = "tech-docs"
     SlackNotificationType      = "Failures"
     BuildNotificationStackName = "di-documentation-notifications"
-    SpokeVpcStackName          = ""
+    SpokeVpcStackName          = "spoke-vpc-idsre"
   }
 
   tags_custom = {

--- a/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
+++ b/terraform/deployments/di-documentation/pipeline-deploy/stacks.tf
@@ -224,6 +224,7 @@ module "tech-docs-pipeline" {
     OneLoginRepositoryName     = "tech-docs"
     SlackNotificationType      = "Failures"
     BuildNotificationStackName = "di-documentation-notifications"
+    SpokeVpcStackName          = ""
   }
 
   tags_custom = {


### PR DESCRIPTION
This PR enables tech-docs-pipeline to use TGW and dual run, a second VPC (SpokeVpcStackName) is needed. The SpokeVPC has already been enabled in an earlier PR ([https://github.com/govuk-one-login/docs-common-infra/pull/22](https://github.com/govuk-one-login/docs-common-infra/pull/22)).

This PR adds the parameter for SpokeVpcStackName to the tech-docs-pipeline module and populates it with the value of the already enabled SpokeVPC (spoke-vpc-idsre). The terraform for this has  been applied. This enables REX to use the SpokeVPC in the tech-docs-pipeline.

The PR also pins the source version of the deploy-pipeline used for tech-docs-pipeline.